### PR TITLE
Fix typo in code for displaying phlay version in the History table

### DIFF
--- a/content.js
+++ b/content.js
@@ -147,7 +147,7 @@ async function fetchCreationMethod() {
     let info = diffinfo.result[id];
     cell.textContent = info.creationMethod;
     if (info.properties && info.properties['phlay:version']) {
-      let phlayVersion = found.properties['phlay:version'];
+      let phlayVersion = info.properties['phlay:version'];
       cell.textContent += ` (v${phlayVersion})`;
     }
     let dateCell = row.querySelector('.date');


### PR DESCRIPTION
This meant that the phlay version for the latest diff was being used for all
phlay entries, which if the latest diff was the final committed one is also
undefined.